### PR TITLE
Update constants to use 0.5.0's `DEF` (#11)

### DIFF
--- a/hardware.inc
+++ b/hardware.inc
@@ -25,40 +25,45 @@
 ;* Rev 2.8 - 03-Feb-19 : Added audio registers flags (Álvaro Cuesta)
 ;* Rev 2.9 - 28-Feb-20 : Added utility rP1 constants
 ;* Rev 3.0 - 27-Aug-20 : Register ordering, byte-based sizes, OAM additions, general cleanup (Blitter Object)
+;* Rev 4.0 - 03-May-21 : Updated to use RGBDS 0.5.0 syntax, changed IEF_LCDC to IEF_STAT (Eievui)
+
+IF __RGBDS_MAJOR__ == 0 && __RGBDS_MINOR__ < 5
+    FAIL "This version of 'hardware.inc' requires RGBDS version 0.5.0 or later."
+ENDC
 
 ; If all of these are already defined, don't do it again.
 
     IF !DEF(HARDWARE_INC)
-HARDWARE_INC SET 1
+DEF HARDWARE_INC EQU 1
 
-rev_Check_hardware_inc : MACRO
+MACRO rev_Check_hardware_inc
 ;NOTE: REVISION NUMBER CHANGES MUST BE ADDED
 ;TO SECOND PARAMETER IN FOLLOWING LINE.
-    IF  \1 > 3.0 ;PUT REVISION NUMBER HERE
+    IF  \1 > 4.0 ;PUT REVISION NUMBER HERE
         WARN    "Version \1 or later of 'hardware.inc' is required."
     ENDC
 ENDM
 
-_VRAM        EQU $8000 ; $8000->$9FFF
-_VRAM8000    EQU _VRAM
-_VRAM8800    EQU _VRAM+$800
-_VRAM9000    EQU _VRAM+$1000
-_SCRN0       EQU $9800 ; $9800->$9BFF
-_SCRN1       EQU $9C00 ; $9C00->$9FFF
-_SRAM        EQU $A000 ; $A000->$BFFF
-_RAM         EQU $C000 ; $C000->$CFFF / $C000->$DFFF
-_RAMBANK     EQU $D000 ; $D000->$DFFF
-_OAMRAM      EQU $FE00 ; $FE00->$FE9F
-_IO          EQU $FF00 ; $FF00->$FF7F,$FFFF
-_AUD3WAVERAM EQU $FF30 ; $FF30->$FF3F
-_HRAM        EQU $FF80 ; $FF80->$FFFE
+DEF _VRAM        EQU $8000 ; $8000->$9FFF
+DEF _VRAM8000    EQU _VRAM
+DEF _VRAM8800    EQU _VRAM+$800
+DEF _VRAM9000    EQU _VRAM+$1000
+DEF _SCRN0       EQU $9800 ; $9800->$9BFF
+DEF _SCRN1       EQU $9C00 ; $9C00->$9FFF
+DEF _SRAM        EQU $A000 ; $A000->$BFFF
+DEF _RAM         EQU $C000 ; $C000->$CFFF / $C000->$DFFF
+DEF _RAMBANK     EQU $D000 ; $D000->$DFFF
+DEF _OAMRAM      EQU $FE00 ; $FE00->$FE9F
+DEF _IO          EQU $FF00 ; $FF00->$FF7F,$FFFF
+DEF _AUD3WAVERAM EQU $FF30 ; $FF30->$FF3F
+DEF _HRAM        EQU $FF80 ; $FF80->$FFFE
 
 ; *** MBC5 Equates ***
 
-rRAMG        EQU $0000 ; $0000->$1fff
-rROMB0       EQU $2000 ; $2000->$2fff
-rROMB1       EQU $3000 ; $3000->$3fff - If more than 256 ROM banks are present.
-rRAMB        EQU $4000 ; $4000->$5fff - Bit 3 enables rumble (if present)
+DEF rRAMG        EQU $0000 ; $0000->$1fff
+DEF rROMB0       EQU $2000 ; $2000->$2fff
+DEF rROMB1       EQU $3000 ; $3000->$3fff - If more than 256 ROM banks are present.
+DEF rRAMB        EQU $4000 ; $4000->$5fff - Bit 3 enables rumble (if present)
 
 
 ;***************************************************************************
@@ -71,74 +76,74 @@ rRAMB        EQU $4000 ; $4000->$5fff - Bit 3 enables rumble (if present)
 ; -- P1 ($FF00)
 ; -- Register for reading joy pad info. (R/W)
 ; --
-rP1 EQU $FF00
+DEF rP1 EQU $FF00
 
-P1F_5 EQU %00100000 ; P15 out port, set to 0 to get buttons
-P1F_4 EQU %00010000 ; P14 out port, set to 0 to get dpad
-P1F_3 EQU %00001000 ; P13 in port
-P1F_2 EQU %00000100 ; P12 in port
-P1F_1 EQU %00000010 ; P11 in port
-P1F_0 EQU %00000001 ; P10 in port
+DEF P1F_5 EQU %00100000 ; P15 out port, set to 0 to get buttons
+DEF P1F_4 EQU %00010000 ; P14 out port, set to 0 to get dpad
+DEF P1F_3 EQU %00001000 ; P13 in port
+DEF P1F_2 EQU %00000100 ; P12 in port
+DEF P1F_1 EQU %00000010 ; P11 in port
+DEF P1F_0 EQU %00000001 ; P10 in port
 
-P1F_GET_DPAD EQU P1F_5
-P1F_GET_BTN  EQU P1F_4
-P1F_GET_NONE EQU P1F_4 | P1F_5
+DEF P1F_GET_DPAD EQU P1F_5
+DEF P1F_GET_BTN  EQU P1F_4
+DEF P1F_GET_NONE EQU P1F_4 | P1F_5
 
 
 ; --
 ; -- SB ($FF01)
 ; -- Serial Transfer Data (R/W)
 ; --
-rSB EQU $FF01
+DEF rSB EQU $FF01
 
 
 ; --
 ; -- SC ($FF02)
 ; -- Serial I/O Control (R/W)
 ; --
-rSC EQU $FF02
+DEF rSC EQU $FF02
 
 
 ; --
 ; -- DIV ($FF04)
 ; -- Divider register (R/W)
 ; --
-rDIV EQU $FF04
+DEF rDIV EQU $FF04
 
 
 ; --
 ; -- TIMA ($FF05)
 ; -- Timer counter (R/W)
 ; --
-rTIMA EQU $FF05
+DEF rTIMA EQU $FF05
 
 
 ; --
 ; -- TMA ($FF06)
 ; -- Timer modulo (R/W)
 ; --
-rTMA EQU $FF06
+DEF rTMA EQU $FF06
 
 
 ; --
 ; -- TAC ($FF07)
 ; -- Timer control (R/W)
 ; --
-rTAC EQU $FF07
+DEF rTAC EQU $FF07
 
-TACF_START  EQU %00000100
-TACF_STOP   EQU %00000000
-TACF_4KHZ   EQU %00000000
-TACF_16KHZ  EQU %00000011
-TACF_65KHZ  EQU %00000010
-TACF_262KHZ EQU %00000001
+DEF TACF_START  EQU %00000100
+DEF TACF_STOP   EQU %00000000
+DEF TACF_4KHZ   EQU %00000000
+DEF TACF_16KHZ  EQU %00000011
+DEF TACF_65KHZ  EQU %00000010
+DEF TACF_262KHZ EQU %00000001
 
 
 ; --
 ; -- IF ($FF0F)
 ; -- Interrupt Flag (R/W)
 ; --
-rIF EQU $FF0F
+DEF rIF EQU $FF0F
 
 
 ; --
@@ -152,11 +157,11 @@ rIF EQU $FF0F
 ; -- Bit 2-0 - Number of sweep shift (# 0-7)
 ; -- Sweep Time: (n*7.8ms)
 ; --
-rNR10 EQU $FF10
-rAUD1SWEEP EQU rNR10
+DEF rNR10 EQU $FF10
+DEF rAUD1SWEEP EQU rNR10
 
-AUD1SWEEP_UP   EQU %00000000
-AUD1SWEEP_DOWN EQU %00001000
+DEF AUD1SWEEP_UP   EQU %00000000
+DEF AUD1SWEEP_DOWN EQU %00001000
 
 
 ; --
@@ -166,8 +171,8 @@ AUD1SWEEP_DOWN EQU %00001000
 ; -- Bit 7-6 - Wave Pattern Duty (00:12.5% 01:25% 10:50% 11:75%)
 ; -- Bit 5-0 - Sound length data (# 0-63)
 ; --
-rNR11 EQU $FF11
-rAUD1LEN EQU rNR11
+DEF rNR11 EQU $FF11
+DEF rAUD1LEN EQU rNR11
 
 
 ; --
@@ -180,16 +185,16 @@ rAUD1LEN EQU rNR11
 ; --           1: Range of increase
 ; -- Bit 2-0 - Number of envelope sweep (# 0-7)
 ; --
-rNR12 EQU $FF12
-rAUD1ENV EQU rNR12
+DEF rNR12 EQU $FF12
+DEF rAUD1ENV EQU rNR12
 
 
 ; --
 ; -- AUD1LOW/NR13 ($FF13)
 ; -- Frequency low byte (W)
 ; --
-rNR13 EQU $FF13
-rAUD1LOW EQU rNR13
+DEF rNR13 EQU $FF13
+DEF rAUD1LOW EQU rNR13
 
 
 ; --
@@ -200,8 +205,8 @@ rAUD1LOW EQU rNR13
 ; -- Bit 6   - Counter/consecutive selection
 ; -- Bit 2-0 - Frequency's higher 3 bits
 ; --
-rNR14 EQU $FF14
-rAUD1HIGH EQU rNR14
+DEF rNR14 EQU $FF14
+DEF rAUD1HIGH EQU rNR14
 
 
 ; --
@@ -210,8 +215,8 @@ rAUD1HIGH EQU rNR14
 ; --
 ; -- see AUD1LEN for info
 ; --
-rNR21 EQU $FF16
-rAUD2LEN EQU rNR21
+DEF rNR21 EQU $FF16
+DEF rAUD2LEN EQU rNR21
 
 
 ; --
@@ -220,16 +225,16 @@ rAUD2LEN EQU rNR21
 ; --
 ; -- see AUD1ENV for info
 ; --
-rNR22 EQU $FF17
-rAUD2ENV EQU rNR22
+DEF rNR22 EQU $FF17
+DEF rAUD2ENV EQU rNR22
 
 
 ; --
 ; -- AUD2LOW/NR23 ($FF18)
 ; -- Frequency low byte (W)
 ; --
-rNR23 EQU $FF18
-rAUD2LOW EQU rNR23
+DEF rNR23 EQU $FF18
+DEF rAUD2LOW EQU rNR23
 
 
 ; --
@@ -238,8 +243,8 @@ rAUD2LOW EQU rNR23
 ; --
 ; -- see AUD1HIGH for info
 ; --
-rNR24 EQU $FF19
-rAUD2HIGH EQU rNR24
+DEF rNR24 EQU $FF19
+DEF rAUD2HIGH EQU rNR24
 
 
 ; --
@@ -248,8 +253,8 @@ rAUD2HIGH EQU rNR24
 ; --
 ; -- Bit 7   - Sound ON/OFF (1=ON,0=OFF)
 ; --
-rNR30 EQU $FF1A
-rAUD3ENA EQU rNR30
+DEF rNR30 EQU $FF1A
+DEF rAUD3ENA EQU rNR30
 
 
 ; --
@@ -258,8 +263,8 @@ rAUD3ENA EQU rNR30
 ; --
 ; -- Bit 7-0 - Sound length
 ; --
-rNR31 EQU $FF1B
-rAUD3LEN EQU rNR31
+DEF rNR31 EQU $FF1B
+DEF rAUD3LEN EQU rNR31
 
 
 ; --
@@ -272,8 +277,8 @@ rAUD3LEN EQU rNR31
 ; --           10: 1/2
 ; --           11: 1/4
 ; --
-rNR32 EQU $FF1C
-rAUD3LEVEL EQU rNR32
+DEF rNR32 EQU $FF1C
+DEF rAUD3LEVEL EQU rNR32
 
 
 ; --
@@ -282,8 +287,8 @@ rAUD3LEVEL EQU rNR32
 ; --
 ; -- see AUD1LOW for info
 ; --
-rNR33 EQU $FF1D
-rAUD3LOW EQU rNR33
+DEF rNR33 EQU $FF1D
+DEF rAUD3LOW EQU rNR33
 
 
 ; --
@@ -292,8 +297,8 @@ rAUD3LOW EQU rNR33
 ; --
 ; -- see AUD1HIGH for info
 ; --
-rNR34 EQU $FF1E
-rAUD3HIGH EQU rNR34
+DEF rNR34 EQU $FF1E
+DEF rAUD3HIGH EQU rNR34
 
 
 ; --
@@ -302,8 +307,8 @@ rAUD3HIGH EQU rNR34
 ; --
 ; -- Bit 5-0 - Sound length data (# 0-63)
 ; --
-rNR41 EQU $FF20
-rAUD4LEN EQU rNR41
+DEF rNR41 EQU $FF20
+DEF rAUD4LEN EQU rNR41
 
 
 ; --
@@ -312,8 +317,8 @@ rAUD4LEN EQU rNR41
 ; --
 ; -- see AUD1ENV for info
 ; --
-rNR42 EQU $FF21
-rAUD4ENV EQU rNR42
+DEF rNR42 EQU $FF21
+DEF rAUD4ENV EQU rNR42
 
 
 ; --
@@ -330,8 +335,8 @@ rAUD4ENV EQU rNR42
 ; --           000: f/4   001: f/8   010: f/16  011: f/24
 ; --           100: f/32  101: f/40  110: f/48  111: f/56  (f=4.194304 Mhz)
 ; --
-rNR43 EQU $FF22
-rAUD4POLY EQU rNR43
+DEF rNR43 EQU $FF22
+DEF rAUD4POLY EQU rNR43
 
 
 ; --
@@ -340,8 +345,8 @@ rAUD4POLY EQU rNR43
 ; -- Bit 7 -   Inital
 ; -- Bit 6 -   Counter/consecutive selection
 ; --
-rNR44 EQU $FF23
-rAUD4GO EQU rNR44
+DEF rNR44 EQU $FF23
+DEF rAUD4GO EQU rNR44
 
 
 ; --
@@ -353,11 +358,11 @@ rAUD4GO EQU rNR44
 ; -- Bit 3   - Vin->SO1 ON/OFF (Vin??)
 ; -- Bit 2-0 - SO1 output level (volume) (# 0-7)
 ; --
-rNR50 EQU $FF24
-rAUDVOL EQU rNR50
+DEF rNR50 EQU $FF24
+DEF rAUDVOL EQU rNR50
 
-AUDVOL_VIN_LEFT  EQU %10000000 ; SO2
-AUDVOL_VIN_RIGHT EQU %00001000 ; SO1
+DEF AUDVOL_VIN_LEFT  EQU %10000000 ; SO2
+DEF AUDVOL_VIN_RIGHT EQU %00001000 ; SO1
 
 
 ; --
@@ -373,19 +378,19 @@ AUDVOL_VIN_RIGHT EQU %00001000 ; SO1
 ; -- Bit 1   - Output sound 2 to SO1 terminal
 ; -- Bit 0   - Output sound 0 to SO1 terminal
 ; --
-rNR51 EQU $FF25
-rAUDTERM EQU rNR51
+DEF rNR51 EQU $FF25
+DEF rAUDTERM EQU rNR51
 
 ; SO2
-AUDTERM_4_LEFT  EQU %10000000
-AUDTERM_3_LEFT  EQU %01000000
-AUDTERM_2_LEFT  EQU %00100000
-AUDTERM_1_LEFT  EQU %00010000
+DEF AUDTERM_4_LEFT  EQU %10000000
+DEF AUDTERM_3_LEFT  EQU %01000000
+DEF AUDTERM_2_LEFT  EQU %00100000
+DEF AUDTERM_1_LEFT  EQU %00010000
 ; SO1
-AUDTERM_4_RIGHT EQU %00001000
-AUDTERM_3_RIGHT EQU %00000100
-AUDTERM_2_RIGHT EQU %00000010
-AUDTERM_1_RIGHT EQU %00000001
+DEF AUDTERM_4_RIGHT EQU %00001000
+DEF AUDTERM_3_RIGHT EQU %00000100
+DEF AUDTERM_2_RIGHT EQU %00000010
+DEF AUDTERM_1_RIGHT EQU %00000001
 
 
 ; --
@@ -398,35 +403,35 @@ AUDTERM_1_RIGHT EQU %00000001
 ; -- Bit 1   - Sound 2 ON flag (read only)
 ; -- Bit 0   - Sound 1 ON flag (read only)
 ; --
-rNR52 EQU $FF26
-rAUDENA EQU rNR52
+DEF rNR52 EQU $FF26
+DEF rAUDENA EQU rNR52
 
-AUDENA_ON    EQU %10000000
-AUDENA_OFF   EQU %00000000  ; sets all audio regs to 0!
+DEF AUDENA_ON    EQU %10000000
+DEF AUDENA_OFF   EQU %00000000  ; sets all audio regs to 0!
 
 
 ; --
 ; -- LCDC ($FF40)
 ; -- LCD Control (R/W)
 ; --
-rLCDC EQU $FF40
+DEF rLCDC EQU $FF40
 
-LCDCF_OFF     EQU %00000000 ; LCD Control Operation
-LCDCF_ON      EQU %10000000 ; LCD Control Operation
-LCDCF_WIN9800 EQU %00000000 ; Window Tile Map Display Select
-LCDCF_WIN9C00 EQU %01000000 ; Window Tile Map Display Select
-LCDCF_WINOFF  EQU %00000000 ; Window Display
-LCDCF_WINON   EQU %00100000 ; Window Display
-LCDCF_BG8800  EQU %00000000 ; BG & Window Tile Data Select
-LCDCF_BG8000  EQU %00010000 ; BG & Window Tile Data Select
-LCDCF_BG9800  EQU %00000000 ; BG Tile Map Display Select
-LCDCF_BG9C00  EQU %00001000 ; BG Tile Map Display Select
-LCDCF_OBJ8    EQU %00000000 ; OBJ Construction
-LCDCF_OBJ16   EQU %00000100 ; OBJ Construction
-LCDCF_OBJOFF  EQU %00000000 ; OBJ Display
-LCDCF_OBJON   EQU %00000010 ; OBJ Display
-LCDCF_BGOFF   EQU %00000000 ; BG Display
-LCDCF_BGON    EQU %00000001 ; BG Display
+DEF LCDCF_OFF     EQU %00000000 ; LCD Control Operation
+DEF LCDCF_ON      EQU %10000000 ; LCD Control Operation
+DEF LCDCF_WIN9800 EQU %00000000 ; Window Tile Map Display Select
+DEF LCDCF_WIN9C00 EQU %01000000 ; Window Tile Map Display Select
+DEF LCDCF_WINOFF  EQU %00000000 ; Window Display
+DEF LCDCF_WINON   EQU %00100000 ; Window Display
+DEF LCDCF_BG8800  EQU %00000000 ; BG & Window Tile Data Select
+DEF LCDCF_BG8000  EQU %00010000 ; BG & Window Tile Data Select
+DEF LCDCF_BG9800  EQU %00000000 ; BG Tile Map Display Select
+DEF LCDCF_BG9C00  EQU %00001000 ; BG Tile Map Display Select
+DEF LCDCF_OBJ8    EQU %00000000 ; OBJ Construction
+DEF LCDCF_OBJ16   EQU %00000100 ; OBJ Construction
+DEF LCDCF_OBJOFF  EQU %00000000 ; OBJ Display
+DEF LCDCF_OBJON   EQU %00000010 ; OBJ Display
+DEF LCDCF_BGOFF   EQU %00000000 ; BG Display
+DEF LCDCF_BGON    EQU %00000001 ; BG Display
 ; "Window Character Data Select" follows BG
 
 
@@ -434,32 +439,32 @@ LCDCF_BGON    EQU %00000001 ; BG Display
 ; -- STAT ($FF41)
 ; -- LCDC Status   (R/W)
 ; --
-rSTAT EQU $FF41
+DEF rSTAT EQU $FF41
 
-STATF_LYC     EQU  %01000000 ; LYC=LY Coincidence (Selectable)
-STATF_MODE10  EQU  %00100000 ; Mode 10
-STATF_MODE01  EQU  %00010000 ; Mode 01 (V-Blank)
-STATF_MODE00  EQU  %00001000 ; Mode 00 (H-Blank)
-STATF_LYCF    EQU  %00000100 ; Coincidence Flag
-STATF_HBL     EQU  %00000000 ; H-Blank
-STATF_VBL     EQU  %00000001 ; V-Blank
-STATF_OAM     EQU  %00000010 ; OAM-RAM is used by system
-STATF_LCD     EQU  %00000011 ; Both OAM and VRAM used by system
-STATF_BUSY    EQU  %00000010 ; When set, VRAM access is unsafe
+DEF STATF_LYC     EQU  %01000000 ; LYC=LY Coincidence (Selectable)
+DEF STATF_MODE10  EQU  %00100000 ; Mode 10
+DEF STATF_MODE01  EQU  %00010000 ; Mode 01 (V-Blank)
+DEF STATF_MODE00  EQU  %00001000 ; Mode 00 (H-Blank)
+DEF STATF_LYCF    EQU  %00000100 ; Coincidence Flag
+DEF STATF_HBL     EQU  %00000000 ; H-Blank
+DEF STATF_VBL     EQU  %00000001 ; V-Blank
+DEF STATF_OAM     EQU  %00000010 ; OAM-RAM is used by system
+DEF STATF_LCD     EQU  %00000011 ; Both OAM and VRAM used by system
+DEF STATF_BUSY    EQU  %00000010 ; When set, VRAM access is unsafe
 
 
 ; --
 ; -- SCY ($FF42)
 ; -- Scroll Y (R/W)
 ; --
-rSCY EQU $FF42
+DEF rSCY EQU $FF42
 
 
 ; --
 ; -- SCX ($FF43)
 ; -- Scroll X (R/W)
 ; --
-rSCX EQU $FF43
+DEF rSCX EQU $FF43
 
 
 ; --
@@ -468,7 +473,7 @@ rSCX EQU $FF43
 ; --
 ; -- Values range from 0->153. 144->153 is the VBlank period.
 ; --
-rLY EQU $FF44
+DEF rLY EQU $FF44
 
 
 ; --
@@ -477,14 +482,14 @@ rLY EQU $FF44
 ; --
 ; -- When LY==LYC, STATF_LYCF will be set in STAT
 ; --
-rLYC EQU $FF45
+DEF rLYC EQU $FF45
 
 
 ; --
 ; -- DMA ($FF46)
 ; -- DMA Transfer and Start Address (W)
 ; --
-rDMA EQU $FF46
+DEF rDMA EQU $FF46
 
 
 ; --
@@ -496,7 +501,7 @@ rDMA EQU $FF46
 ; -- Bit 3-2 - Intensity for %01
 ; -- Bit 1-0 - Intensity for %00
 ; --
-rBGP EQU $FF47
+DEF rBGP EQU $FF47
 
 
 ; --
@@ -505,7 +510,7 @@ rBGP EQU $FF47
 ; --
 ; -- See BGP for info
 ; --
-rOBP0 EQU $FF48
+DEF rOBP0 EQU $FF48
 
 
 ; --
@@ -514,7 +519,7 @@ rOBP0 EQU $FF48
 ; --
 ; -- See BGP for info
 ; --
-rOBP1 EQU $FF49
+DEF rOBP1 EQU $FF49
 
 
 ; --
@@ -524,7 +529,7 @@ rOBP1 EQU $FF49
 ; -- 0 <= WY <= 143
 ; -- When WY = 0, the window is displayed from the top edge of the LCD screen.
 ; --
-rWY EQU $FF4A
+DEF rWY EQU $FF4A
 
 
 ; --
@@ -535,18 +540,18 @@ rWY EQU $FF4A
 ; -- When WX = 7, the window is displayed from the left edge of the LCD screen.
 ; -- Values of 0-6 and 166 are unreliable due to hardware bugs.
 ; --
-rWX EQU $FF4B
+DEF rWX EQU $FF4B
 
 
 ; --
 ; -- SPEED ($FF4D)
 ; -- Select CPU Speed (R/W)
 ; --
-rKEY1 EQU $FF4D
-rSPD  EQU rKEY1
+DEF rKEY1 EQU $FF4D
+DEF rSPD  EQU rKEY1
 
-KEY1F_DBLSPEED EQU %10000000 ; 0=Normal Speed, 1=Double Speed (R)
-KEY1F_PREPARE  EQU %00000001 ; 0=No, 1=Prepare (R/W)
+DEF KEY1F_DBLSPEED EQU %10000000 ; 0=Normal Speed, 1=Double Speed (R)
+DEF KEY1F_PREPARE  EQU %00000001 ; 0=No, 1=Prepare (R/W)
 
 
 ; --
@@ -555,7 +560,7 @@ KEY1F_PREPARE  EQU %00000001 ; 0=No, 1=Prepare (R/W)
 ; --
 ; -- Bit 0 - Bank Specification (0: Specify Bank 0; 1: Specify Bank 1)
 ; --
-rVBK EQU $FF4F
+DEF rVBK EQU $FF4F
 
 
 ; --
@@ -563,7 +568,7 @@ rVBK EQU $FF4F
 ; -- High byte for Horizontal Blanking/General Purpose DMA source address (W)
 ; -- CGB Mode Only
 ; --
-rHDMA1 EQU $FF51
+DEF rHDMA1 EQU $FF51
 
 
 ; --
@@ -571,7 +576,7 @@ rHDMA1 EQU $FF51
 ; -- Low byte for Horizontal Blanking/General Purpose DMA source address (W)
 ; -- CGB Mode Only
 ; --
-rHDMA2 EQU $FF52
+DEF rHDMA2 EQU $FF52
 
 
 ; --
@@ -579,7 +584,7 @@ rHDMA2 EQU $FF52
 ; -- High byte for Horizontal Blanking/General Purpose DMA destination address (W)
 ; -- CGB Mode Only
 ; --
-rHDMA3 EQU $FF53
+DEF rHDMA3 EQU $FF53
 
 
 ; --
@@ -587,7 +592,7 @@ rHDMA3 EQU $FF53
 ; -- Low byte for Horizontal Blanking/General Purpose DMA destination address (W)
 ; -- CGB Mode Only
 ; --
-rHDMA4 EQU $FF54
+DEF rHDMA4 EQU $FF54
 
 
 ; --
@@ -595,13 +600,13 @@ rHDMA4 EQU $FF54
 ; -- Transfer length (in tiles minus 1)/mode/start for Horizontal Blanking, General Purpose DMA (R/W)
 ; -- CGB Mode Only
 ; --
-rHDMA5 EQU $FF55
+DEF rHDMA5 EQU $FF55
 
-HDMA5F_MODE_GP  EQU %00000000 ; General Purpose DMA (W)
-HDMA5F_MODE_HBL EQU %10000000 ; HBlank DMA (W)
+DEF HDMA5F_MODE_GP  EQU %00000000 ; General Purpose DMA (W)
+DEF HDMA5F_MODE_HBL EQU %10000000 ; HBlank DMA (W)
 
 ; -- Once DMA has started, use HDMA5F_BUSY to check when the transfer is complete
-HDMA5F_BUSY EQU %10000000 ; 0=Busy (DMA still in progress), 1=Transfer complete (R)
+DEF HDMA5F_BUSY EQU %10000000 ; 0=Busy (DMA still in progress), 1=Transfer complete (R)
 
 
 ; --
@@ -609,44 +614,44 @@ HDMA5F_BUSY EQU %10000000 ; 0=Busy (DMA still in progress), 1=Transfer complete 
 ; -- Infrared Communications Port (R/W)
 ; -- CGB Mode Only
 ; --
-rRP EQU $FF56
+DEF rRP EQU $FF56
 
-RPF_ENREAD   EQU %11000000
-RPF_DATAIN   EQU %00000010 ; 0=Receiving IR Signal, 1=Normal
-RPF_WRITE_HI EQU %00000001
-RPF_WRITE_LO EQU %00000000
+DEF RPF_ENREAD   EQU %11000000
+DEF RPF_DATAIN   EQU %00000010 ; 0=Receiving IR Signal, 1=Normal
+DEF RPF_WRITE_HI EQU %00000001
+DEF RPF_WRITE_LO EQU %00000000
 
 
 ; --
 ; -- BCPS ($FF68)
 ; -- Background Color Palette Specification (R/W)
 ; --
-rBCPS EQU $FF68
+DEF rBCPS EQU $FF68
 
-BCPSF_AUTOINC EQU %10000000 ; Auto Increment (0=Disabled, 1=Increment after Writing)
+DEF BCPSF_AUTOINC EQU %10000000 ; Auto Increment (0=Disabled, 1=Increment after Writing)
 
 
 ; --
 ; -- BCPD ($FF69)
 ; -- Background Color Palette Data (R/W)
 ; --
-rBCPD EQU $FF69
+DEF rBCPD EQU $FF69
 
 
 ; --
 ; -- OCPS ($FF6A)
 ; -- Object Color Palette Specification (R/W)
 ; --
-rOCPS EQU $FF6A
+DEF rOCPS EQU $FF6A
 
-OCPSF_AUTOINC EQU %10000000 ; Auto Increment (0=Disabled, 1=Increment after Writing)
+DEF OCPSF_AUTOINC EQU %10000000 ; Auto Increment (0=Disabled, 1=Increment after Writing)
 
 
 ; --
 ; -- OCPD ($FF6B)
 ; -- Object Color Palette Data (R/W)
 ; --
-rOCPD EQU $FF6B
+DEF rOCPD EQU $FF6B
 
 
 ; --
@@ -655,8 +660,8 @@ rOCPD EQU $FF6B
 ; --
 ; -- Bit 2-0 - Bank Specification (0,1: Specify Bank 1; 2-7: Specify Banks 2-7)
 ; --
-rSVBK EQU $FF70
-rSMBK EQU rSVBK
+DEF rSVBK EQU $FF70
+DEF rSMBK EQU rSVBK
 
 
 ; --
@@ -666,7 +671,7 @@ rSMBK EQU rSVBK
 ; -- Bit 7-4 - Copy of sound channel 2's PCM amplitude
 ; -- Bit 3-0 - Copy of sound channel 1's PCM amplitude
 ; --
-rPCM12 EQU $FF76
+DEF rPCM12 EQU $FF76
 
 
 ; --
@@ -676,20 +681,20 @@ rPCM12 EQU $FF76
 ; -- Bit 7-4 - Copy of sound channel 4's PCM amplitude
 ; -- Bit 3-0 - Copy of sound channel 3's PCM amplitude
 ; --
-rPCM34 EQU $FF77
+DEF rPCM34 EQU $FF77
 
 
 ; --
 ; -- IE ($FFFF)
 ; -- Interrupt Enable (R/W)
 ; --
-rIE EQU $FFFF
+DEF rIE EQU $FFFF
 
-IEF_HILO   EQU %00010000 ; Transition from High to Low of Pin number P10-P13
-IEF_SERIAL EQU %00001000 ; Serial I/O transfer end
-IEF_TIMER  EQU %00000100 ; Timer Overflow
-IEF_LCDC   EQU %00000010 ; LCDC (see STAT)
-IEF_VBLANK EQU %00000001 ; V-Blank
+DEF IEF_HILO   EQU %00010000 ; Transition from High to Low of Pin number P10-P13
+DEF IEF_SERIAL EQU %00001000 ; Serial I/O transfer end
+DEF IEF_TIMER  EQU %00000100 ; Timer Overflow
+DEF IEF_STAT   EQU %00000010 ; STAT
+DEF IEF_VBLANK EQU %00000001 ; V-Blank
 
 
 ;***************************************************************************
@@ -704,10 +709,10 @@ IEF_VBLANK EQU %00000001 ; V-Blank
 ; -- Can be used with AUD1LEN and AUD2LEN
 ; -- See AUD1LEN for more info
 ; --
-AUDLEN_DUTY_12_5    EQU %00000000 ; 12.5%
-AUDLEN_DUTY_25      EQU %01000000 ; 25%
-AUDLEN_DUTY_50      EQU %10000000 ; 50%
-AUDLEN_DUTY_75      EQU %11000000 ; 75%
+DEF AUDLEN_DUTY_12_5    EQU %00000000 ; 12.5%
+DEF AUDLEN_DUTY_25      EQU %01000000 ; 25%
+DEF AUDLEN_DUTY_50      EQU %10000000 ; 50%
+DEF AUDLEN_DUTY_75      EQU %11000000 ; 75%
 
 
 ; --
@@ -716,8 +721,8 @@ AUDLEN_DUTY_75      EQU %11000000 ; 75%
 ; -- Can be used with AUD1ENV, AUD2ENV, AUD4ENV
 ; -- See AUD1ENV for more info
 ; --
-AUDENV_UP           EQU %00001000
-AUDENV_DOWN         EQU %00000000
+DEF AUDENV_UP           EQU %00001000
+DEF AUDENV_DOWN         EQU %00000000
 
 
 ; --
@@ -727,9 +732,9 @@ AUDENV_DOWN         EQU %00000000
 ; -- See AUD1HIGH for more info
 ; --
 
-AUDHIGH_RESTART     EQU %10000000
-AUDHIGH_LENGTH_ON   EQU %01000000
-AUDHIGH_LENGTH_OFF  EQU %00000000
+DEF AUDHIGH_RESTART     EQU %10000000
+DEF AUDHIGH_LENGTH_ON   EQU %01000000
+DEF AUDHIGH_LENGTH_OFF  EQU %00000000
 
 
 ;***************************************************************************
@@ -738,14 +743,14 @@ AUDHIGH_LENGTH_OFF  EQU %00000000
 ;*
 ;***************************************************************************
 
-BOOTUP_A_DMG    EQU $01 ; Dot Matrix Game
-BOOTUP_A_CGB    EQU $11 ; Color GameBoy
-BOOTUP_A_MGB    EQU $FF ; Mini GameBoy (Pocket GameBoy)
+DEF BOOTUP_A_DMG    EQU $01 ; Dot Matrix Game
+DEF BOOTUP_A_CGB    EQU $11 ; Color GameBoy
+DEF BOOTUP_A_MGB    EQU $FF ; Mini GameBoy (Pocket GameBoy)
 
 ; if a=BOOTUP_A_CGB, bit 0 in b can be checked to determine if real CGB or
 ; other system running in GBC mode
-BOOTUP_B_CGB    EQU %00000000
-BOOTUP_B_AGB    EQU %00000001   ; GBA, GBA SP, Game Boy Player, or New GBA SP
+DEF BOOTUP_B_CGB    EQU %00000000
+DEF BOOTUP_B_AGB    EQU %00000001   ; GBA, GBA SP, Game Boy Player, or New GBA SP
 
 
 ;***************************************************************************
@@ -755,72 +760,72 @@ BOOTUP_B_AGB    EQU %00000001   ; GBA, GBA SP, Game Boy Player, or New GBA SP
 ;***************************************************************************
 
 ; $0143 Color GameBoy compatibility code
-CART_COMPATIBLE_DMG     EQU $00
-CART_COMPATIBLE_DMG_GBC EQU $80
-CART_COMPATIBLE_GBC     EQU $C0
+DEF CART_COMPATIBLE_DMG     EQU $00
+DEF CART_COMPATIBLE_DMG_GBC EQU $80
+DEF CART_COMPATIBLE_GBC     EQU $C0
 
 ; $0146 GameBoy/Super GameBoy indicator
-CART_INDICATOR_GB       EQU $00
-CART_INDICATOR_SGB      EQU $03
+DEF CART_INDICATOR_GB       EQU $00
+DEF CART_INDICATOR_SGB      EQU $03
 
 ; $0147 Cartridge type
-CART_ROM                     EQU $00
-CART_ROM_MBC1                EQU $01
-CART_ROM_MBC1_RAM            EQU $02
-CART_ROM_MBC1_RAM_BAT        EQU $03
-CART_ROM_MBC2                EQU $05
-CART_ROM_MBC2_BAT            EQU $06
-CART_ROM_RAM                 EQU $08
-CART_ROM_RAM_BAT             EQU $09
-CART_ROM_MMM01               EQU $0B
-CART_ROM_MMM01_RAM           EQU $0C
-CART_ROM_MMM01_RAM_BAT       EQU $0D
-CART_ROM_MBC3_BAT_RTC        EQU $0F
-CART_ROM_MBC3_RAM_BAT_RTC    EQU $10
-CART_ROM_MBC3                EQU $11
-CART_ROM_MBC3_RAM            EQU $12
-CART_ROM_MBC3_RAM_BAT        EQU $13
-CART_ROM_MBC5                EQU $19
-CART_ROM_MBC5_BAT            EQU $1A
-CART_ROM_MBC5_RAM_BAT        EQU $1B
-CART_ROM_MBC5_RUMBLE         EQU $1C
-CART_ROM_MBC5_RAM_RUMBLE     EQU $1D
-CART_ROM_MBC5_RAM_BAT_RUMBLE EQU $1E
-CART_ROM_MBC7_RAM_BAT_GYRO   EQU $22
-CART_ROM_POCKET_CAMERA       EQU $FC
-CART_ROM_BANDAI_TAMA5        EQU $FD
-CART_ROM_HUDSON_HUC3         EQU $FE
-CART_ROM_HUDSON_HUC1         EQU $FF
+DEF CART_ROM                     EQU $00
+DEF CART_ROM_MBC1                EQU $01
+DEF CART_ROM_MBC1_RAM            EQU $02
+DEF CART_ROM_MBC1_RAM_BAT        EQU $03
+DEF CART_ROM_MBC2                EQU $05
+DEF CART_ROM_MBC2_BAT            EQU $06
+DEF CART_ROM_RAM                 EQU $08
+DEF CART_ROM_RAM_BAT             EQU $09
+DEF CART_ROM_MMM01               EQU $0B
+DEF CART_ROM_MMM01_RAM           EQU $0C
+DEF CART_ROM_MMM01_RAM_BAT       EQU $0D
+DEF CART_ROM_MBC3_BAT_RTC        EQU $0F
+DEF CART_ROM_MBC3_RAM_BAT_RTC    EQU $10
+DEF CART_ROM_MBC3                EQU $11
+DEF CART_ROM_MBC3_RAM            EQU $12
+DEF CART_ROM_MBC3_RAM_BAT        EQU $13
+DEF CART_ROM_MBC5                EQU $19
+DEF CART_ROM_MBC5_BAT            EQU $1A
+DEF CART_ROM_MBC5_RAM_BAT        EQU $1B
+DEF CART_ROM_MBC5_RUMBLE         EQU $1C
+DEF CART_ROM_MBC5_RAM_RUMBLE     EQU $1D
+DEF CART_ROM_MBC5_RAM_BAT_RUMBLE EQU $1E
+DEF CART_ROM_MBC7_RAM_BAT_GYRO   EQU $22
+DEF CART_ROM_POCKET_CAMERA       EQU $FC
+DEF CART_ROM_BANDAI_TAMA5        EQU $FD
+DEF CART_ROM_HUDSON_HUC3         EQU $FE
+DEF CART_ROM_HUDSON_HUC1         EQU $FF
 
 ; $0148 ROM size
 ; these are kilobytes
-CART_ROM_32KB   EQU $00 ; 2 banks
-CART_ROM_64KB   EQU $01 ; 4 banks
-CART_ROM_128KB  EQU $02 ; 8 banks
-CART_ROM_256KB  EQU $03 ; 16 banks
-CART_ROM_512KB  EQU $04 ; 32 banks
-CART_ROM_1024KB EQU $05 ; 64 banks
-CART_ROM_2048KB EQU $06 ; 128 banks
-CART_ROM_4096KB EQU $07 ; 256 banks
-CART_ROM_8192KB EQU $08 ; 512 banks
-CART_ROM_1152KB EQU $52 ; 72 banks
-CART_ROM_1280KB EQU $53 ; 80 banks
-CART_ROM_1536KB EQU $54 ; 96 banks
+DEF CART_ROM_32KB   EQU $00 ; 2 banks
+DEF CART_ROM_64KB   EQU $01 ; 4 banks
+DEF CART_ROM_128KB  EQU $02 ; 8 banks
+DEF CART_ROM_256KB  EQU $03 ; 16 banks
+DEF CART_ROM_512KB  EQU $04 ; 32 banks
+DEF CART_ROM_1024KB EQU $05 ; 64 banks
+DEF CART_ROM_2048KB EQU $06 ; 128 banks
+DEF CART_ROM_4096KB EQU $07 ; 256 banks
+DEF CART_ROM_8192KB EQU $08 ; 512 banks
+DEF CART_ROM_1152KB EQU $52 ; 72 banks
+DEF CART_ROM_1280KB EQU $53 ; 80 banks
+DEF CART_ROM_1536KB EQU $54 ; 96 banks
 
 ; $0149 SRAM size
 ; these are kilobytes
-CART_SRAM_NONE  EQU 0
-CART_SRAM_2KB   EQU 1 ; 1 incomplete bank
-CART_SRAM_8KB   EQU 2 ; 1 bank
-CART_SRAM_32KB  EQU 3 ; 4 banks
-CART_SRAM_128KB EQU 4 ; 16 banks
+DEF CART_SRAM_NONE  EQU 0
+DEF CART_SRAM_2KB   EQU 1 ; 1 incomplete bank
+DEF CART_SRAM_8KB   EQU 2 ; 1 bank
+DEF CART_SRAM_32KB  EQU 3 ; 4 banks
+DEF CART_SRAM_128KB EQU 4 ; 16 banks
 
-CART_SRAM_ENABLE  EQU $0A
-CART_SRAM_DISABLE EQU $00
+DEF CART_SRAM_ENABLE  EQU $0A
+DEF CART_SRAM_DISABLE EQU $00
 
 ; $014A Destination code
-CART_DEST_JAPANESE     EQU $00
-CART_DEST_NON_JAPANESE EQU $01
+DEF CART_DEST_JAPANESE     EQU $00
+DEF CART_DEST_NON_JAPANESE EQU $01
 
 
 ;***************************************************************************
@@ -829,23 +834,23 @@ CART_DEST_NON_JAPANESE EQU $01
 ;*
 ;***************************************************************************
 
-PADF_DOWN   EQU $80
-PADF_UP     EQU $40
-PADF_LEFT   EQU $20
-PADF_RIGHT  EQU $10
-PADF_START  EQU $08
-PADF_SELECT EQU $04
-PADF_B      EQU $02
-PADF_A      EQU $01
+DEF PADF_DOWN   EQU $80
+DEF PADF_UP     EQU $40
+DEF PADF_LEFT   EQU $20
+DEF PADF_RIGHT  EQU $10
+DEF PADF_START  EQU $08
+DEF PADF_SELECT EQU $04
+DEF PADF_B      EQU $02
+DEF PADF_A      EQU $01
 
-PADB_DOWN   EQU $7
-PADB_UP     EQU $6
-PADB_LEFT   EQU $5
-PADB_RIGHT  EQU $4
-PADB_START  EQU $3
-PADB_SELECT EQU $2
-PADB_B      EQU $1
-PADB_A      EQU $0
+DEF PADB_DOWN   EQU $7
+DEF PADB_UP     EQU $6
+DEF PADB_LEFT   EQU $5
+DEF PADB_RIGHT  EQU $4
+DEF PADB_START  EQU $3
+DEF PADB_SELECT EQU $2
+DEF PADB_B      EQU $1
+DEF PADB_A      EQU $0
 
 
 ;***************************************************************************
@@ -854,15 +859,15 @@ PADB_A      EQU $0
 ;*
 ;***************************************************************************
 
-SCRN_X    EQU 160 ; Width of screen in pixels
-SCRN_Y    EQU 144 ; Height of screen in pixels
-SCRN_X_B  EQU 20  ; Width of screen in bytes
-SCRN_Y_B  EQU 18  ; Height of screen in bytes
+DEF SCRN_X    EQU 160 ; Width of screen in pixels
+DEF SCRN_Y    EQU 144 ; Height of screen in pixels
+DEF SCRN_X_B  EQU 20  ; Width of screen in bytes
+DEF SCRN_Y_B  EQU 18  ; Height of screen in bytes
 
-SCRN_VX   EQU 256 ; Virtual width of screen in pixels
-SCRN_VY   EQU 256 ; Virtual height of screen in pixels
-SCRN_VX_B EQU 32  ; Virtual width of screen in bytes
-SCRN_VY_B EQU 32  ; Virtual height of screen in bytes
+DEF SCRN_VX   EQU 256 ; Virtual width of screen in pixels
+DEF SCRN_VY   EQU 256 ; Virtual height of screen in pixels
+DEF SCRN_VX_B EQU 32  ; Virtual width of screen in bytes
+DEF SCRN_VY_B EQU 32  ; Virtual height of screen in bytes
 
 
 ;***************************************************************************
@@ -874,40 +879,44 @@ SCRN_VY_B EQU 32  ; Virtual height of screen in bytes
 ; OAM attributes
 ; each entry in OAM RAM is 4 bytes (sizeof_OAM_ATTRS)
 RSRESET
-OAMA_Y              RB  1   ; y pos
-OAMA_X              RB  1   ; x pos
-OAMA_TILEID         RB  1   ; tile id
-OAMA_FLAGS          RB  1   ; flags (see below)
-sizeof_OAM_ATTRS    RB  0
+DEF OAMA_Y              RB  1   ; y pos
+DEF OAMA_X              RB  1   ; x pos
+DEF OAMA_TILEID         RB  1   ; tile id
+DEF OAMA_FLAGS          RB  1   ; flags (see below)
+DEF sizeof_OAM_ATTRS    RB  0
 
-OAM_COUNT           EQU 40  ; number of OAM entries in OAM RAM
+DEF OAM_COUNT           EQU 40  ; number of OAM entries in OAM RAM
 
 ; flags
-OAMF_PRI        EQU %10000000 ; Priority
-OAMF_YFLIP      EQU %01000000 ; Y flip
-OAMF_XFLIP      EQU %00100000 ; X flip
-OAMF_PAL0       EQU %00000000 ; Palette number; 0,1 (DMG)
-OAMF_PAL1       EQU %00010000 ; Palette number; 0,1 (DMG)
-OAMF_BANK0      EQU %00000000 ; Bank number; 0,1 (GBC)
-OAMF_BANK1      EQU %00001000 ; Bank number; 0,1 (GBC)
+DEF OAMF_PRI        EQU %10000000 ; Priority
+DEF OAMF_YFLIP      EQU %01000000 ; Y flip
+DEF OAMF_XFLIP      EQU %00100000 ; X flip
+DEF OAMF_PAL0       EQU %00000000 ; Palette number; 0,1 (DMG)
+DEF OAMF_PAL1       EQU %00010000 ; Palette number; 0,1 (DMG)
+DEF OAMF_BANK0      EQU %00000000 ; Bank number; 0,1 (GBC)
+DEF OAMF_BANK1      EQU %00001000 ; Bank number; 0,1 (GBC)
 
-OAMF_PALMASK    EQU %00000111 ; Palette (GBC)
+DEF OAMF_PALMASK    EQU %00000111 ; Palette (GBC)
 
-OAMB_PRI        EQU 7 ; Priority
-OAMB_YFLIP      EQU 6 ; Y flip
-OAMB_XFLIP      EQU 5 ; X flip
-OAMB_PAL1       EQU 4 ; Palette number; 0,1 (DMG)
-OAMB_BANK1      EQU 3 ; Bank number; 0,1 (GBC)
+DEF OAMB_PRI        EQU 7 ; Priority
+DEF OAMB_YFLIP      EQU 6 ; Y flip
+DEF OAMB_XFLIP      EQU 5 ; X flip
+DEF OAMB_PAL1       EQU 4 ; Palette number; 0,1 (DMG)
+DEF OAMB_BANK1      EQU 3 ; Bank number; 0,1 (GBC)
 
 
 ;*
 ;* Nintendo scrolling logo
 ;* (Code won't work on a real GameBoy)
 ;* (if next lines are altered.)
-NINTENDO_LOGO : MACRO
+MACRO NINTENDO_LOGO
     DB  $CE,$ED,$66,$66,$CC,$0D,$00,$0B,$03,$73,$00,$83,$00,$0C,$00,$0D
     DB  $00,$08,$11,$1F,$88,$89,$00,$0E,$DC,$CC,$6E,$E6,$DD,$DD,$D9,$99
     DB  $BB,$BB,$67,$63,$6E,$0E,$EC,$CC,$DD,$DC,$99,$9F,$BB,$B9,$33,$3E
 ENDM
+
+; Deprecated constants. Please avoid using.
+
+DEF IEF_LCDC   EQU %00000010 ; LCDC (see STAT)
 
     ENDC ;HARDWARE_INC


### PR DESCRIPTION
Also updated the Nintendo logo macro.

Bumped major version to 4.0, since this breaks compatibility with RGBDS versions prior to 0.5.0.

3 -> 03, updated rev check macro

* Deprecate `IEF_LCDC` in favor of `IEF_STAT`

* Adde check for outdated RGBDS versions

* Update include guard to use `EQU`